### PR TITLE
Update about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-title: About
+title: accenture.github.io | Accenture contributes to the open source community
 permalink: /
 
 head_h: We believe in the power of open source


### PR DESCRIPTION
When you saving link in OneNote or share it becomes fully non-informative. 
![Screenshot 2024-12-06 161818](https://github.com/user-attachments/assets/f6bd5de5-2806-4ada-867c-898b0a0bfa2d)

Therefore I propose to replace title for the site to more expressive. 